### PR TITLE
Add set Tenderly credentials method

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "1.0.0",
   "private": true,
   "description": "A MetaMask Snap with transaction preview powered by Tenderly Simulation API.",
+  "keywords": [
+    "metamask",
+    "metamask-snap",
+    "tenderly",
+    "web3",
+    "blockchain",
+    "ethereum"
+  ],
   "homepage": "https://github.com/Tenderly/tenderly-snap#readme",
   "bugs": {
     "url": "https://github.com/Tenderly/tenderly-snap/issues"

--- a/packages/site/src/utils/constants.ts
+++ b/packages/site/src/utils/constants.ts
@@ -1,5 +1,6 @@
 enum CustomRequestMethod {
   UPDATE_TENDERLY_CREDENTIALS = 'update_tenderly_credentials',
+  SET_TENDERLY_CREDENTIALS = 'set_tenderly_credentials',
   SEND_TENDERLY_TRANSACTION = 'send_tenderly_transaction',
 }
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tenderly/tenderly-snap.git"
   },
   "source": {
-    "shasum": "9dA2728QNhJQPJi3hfCl92f3mT9GX+R9j/+klFkp73Y=",
+    "shasum": "3aKCNn3g+caVI9Fb6sIeVuh5qgtBmZN8jlWMIOBdPxE=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tenderly/tenderly-snap.git"
   },
   "source": {
-    "shasum": "0hMDMp44job6q28feQRrbPNUc8D2U6M1W4G7ZZdy1Nk=",
+    "shasum": "9dA2728QNhJQPJi3hfCl92f3mT9GX+R9j/+klFkp73Y=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tenderly/tenderly-snap.git"
   },
   "source": {
-    "shasum": "3aKCNn3g+caVI9Fb6sIeVuh5qgtBmZN8jlWMIOBdPxE=",
+    "shasum": "9MzJfo6yPb56RbGqvYz1E9WeSBoHw1DH/3NjlWy94So=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/constants.ts
+++ b/packages/snap/src/constants.ts
@@ -1,5 +1,6 @@
 enum CustomRequestMethod {
   UPDATE_TENDERLY_CREDENTIALS = 'update_tenderly_credentials',
+  SET_TENDERLY_CREDENTIALS = 'set_tenderly_credentials',
   SEND_TENDERLY_TRANSACTION = 'send_tenderly_transaction',
 }
 

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -9,6 +9,7 @@ import {
   handleUpdateTenderlyCredentials,
   handleSetTenderlyCredentials,
   simulate,
+  isTenderlyDomain,
 } from './tenderly';
 import { CustomRequestMethod } from './constants';
 
@@ -26,8 +27,15 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case CustomRequestMethod.UPDATE_TENDERLY_CREDENTIALS:
       return handleUpdateTenderlyCredentials(origin);
-    case CustomRequestMethod.SET_TENDERLY_CREDENTIALS:
+    case CustomRequestMethod.SET_TENDERLY_CREDENTIALS: {
+      if (!isTenderlyDomain(origin)) {
+        throw new Error(
+          'The origin of the request must be sent from the Tenderly domain.',
+        );
+      }
+
       return handleSetTenderlyCredentials(request);
+    }
     case CustomRequestMethod.SEND_TENDERLY_TRANSACTION:
       return handleSendTenderlyTransaction(origin);
     default:

--- a/packages/snap/src/index.ts
+++ b/packages/snap/src/index.ts
@@ -7,6 +7,7 @@ import { hasProperty, isObject } from '@metamask/utils';
 import {
   handleSendTenderlyTransaction,
   handleUpdateTenderlyCredentials,
+  handleSetTenderlyCredentials,
   simulate,
 } from './tenderly';
 import { CustomRequestMethod } from './constants';
@@ -25,6 +26,8 @@ export const onRpcRequest: OnRpcRequestHandler = ({ origin, request }) => {
   switch (request.method) {
     case CustomRequestMethod.UPDATE_TENDERLY_CREDENTIALS:
       return handleUpdateTenderlyCredentials(origin);
+    case CustomRequestMethod.SET_TENDERLY_CREDENTIALS:
+      return handleSetTenderlyCredentials(request);
     case CustomRequestMethod.SEND_TENDERLY_TRANSACTION:
       return handleSendTenderlyTransaction(origin);
     default:

--- a/packages/snap/src/tenderly/__tests__/utils.test.ts
+++ b/packages/snap/src/tenderly/__tests__/utils.test.ts
@@ -1,0 +1,39 @@
+import { expect } from '@jest/globals';
+import { isTenderlyDomain } from '../utils';
+
+describe('Tenderly Utils', () => {
+  describe('isTenderlyDomain', () => {
+    it('returns true', () => {
+      expect(isTenderlyDomain('https://dashboard.tenderly.co')).toBe(true);
+      expect(isTenderlyDomain('https://dashboard.tenderly.co/')).toBe(true);
+      expect(isTenderlyDomain('https://dashboard.tenderly.co?test=123')).toBe(
+        true,
+      );
+
+      expect(
+        isTenderlyDomain(
+          'https://dashboard.tenderly.co/tx/mainnet/0xa25266fb400027add84eebdcd300d5404859dd5c4ec56a0f37e88c4df0246857?trace=0',
+        ),
+      ).toBe(true);
+
+      expect(
+        isTenderlyDomain(
+          'https://dashboard.tenderly.co/dzimiks-tenderly/metamask-snap/simulator/new?block=&blockIndex=0&from=0x0000000000000000000000000000000000000000&gas=8000000&gasPrice=0&value=0',
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false', () => {
+      expect(isTenderlyDomain('http://dashboard.tenderly.co')).toBe(false);
+      expect(isTenderlyDomain('http://tenderly.co')).toBe(false);
+      expect(isTenderlyDomain('https://dashboard.tenderly.com')).toBe(false);
+      expect(isTenderlyDomain('https://tenderly.com')).toBe(false);
+      expect(isTenderlyDomain('https://google.com/tenderly.co')).toBe(false);
+      expect(isTenderlyDomain('https://tenderly.co.website.com')).toBe(false);
+      expect(isTenderlyDomain('https://status.tenderly.co')).toBe(false);
+      expect(isTenderlyDomain('https://tenderly.co')).toBe(false);
+      expect(isTenderlyDomain('https://tenderly.co/devnets')).toBe(false);
+      expect(isTenderlyDomain('https://tenderly.co/?test=123')).toBe(false);
+    });
+  });
+});

--- a/packages/snap/src/tenderly/__tests__/utils.test.ts
+++ b/packages/snap/src/tenderly/__tests__/utils.test.ts
@@ -6,6 +6,10 @@ describe('Tenderly Utils', () => {
     it('returns true', () => {
       expect(isTenderlyDomain('https://dashboard.tenderly.co')).toBe(true);
       expect(isTenderlyDomain('https://dashboard.tenderly.co/')).toBe(true);
+      expect(
+        isTenderlyDomain('https://dashboard.tenderly.co/account/authorization'),
+      ).toBe(true);
+
       expect(isTenderlyDomain('https://dashboard.tenderly.co?test=123')).toBe(
         true,
       );
@@ -30,6 +34,9 @@ describe('Tenderly Utils', () => {
       expect(isTenderlyDomain('https://tenderly.com')).toBe(false);
       expect(isTenderlyDomain('https://google.com/tenderly.co')).toBe(false);
       expect(isTenderlyDomain('https://tenderly.co.website.com')).toBe(false);
+      expect(
+        isTenderlyDomain('https://dashboard.tenderly.co.website.com'),
+      ).toBe(false);
       expect(isTenderlyDomain('https://status.tenderly.co')).toBe(false);
       expect(isTenderlyDomain('https://tenderly.co')).toBe(false);
       expect(isTenderlyDomain('https://tenderly.co/devnets')).toBe(false);

--- a/packages/snap/src/tenderly/credentials-access.ts
+++ b/packages/snap/src/tenderly/credentials-access.ts
@@ -1,4 +1,5 @@
 import { panel, text, heading } from '@metamask/snaps-ui';
+import { JsonRpcRequest } from '@metamask/utils';
 import { requestSnapPrompt } from './utils';
 
 export type TenderlyCredentials = {
@@ -43,6 +44,57 @@ export async function handleUpdateTenderlyCredentials(origin: string) {
     params: {
       operation: 'update',
       newState: tenderlyAccess,
+    },
+  });
+
+  return null;
+}
+
+/**
+ * Sets the credentials associated with Tenderly project.
+ * This method updates the snap state with the provided Tenderly credentials.
+ *
+ * @param request - The JSON-RPC request containing Tenderly credentials.
+ * @throws Will throw an error if the request object or its params are missing.
+ * @throws Will throw an error if any of the required Tenderly credentials are missing.
+ * @example
+ * await window.ethereum.request({
+ *   method: 'wallet_invokeSnap',
+ *   params: {
+ *     snapId: 'npm:@tenderly/metamask-snap',
+ *     request: {
+ *       method: 'set_tenderly_credentials',
+ *       params: {
+ *         accountId: 'TENDERLY_ACCOUNT_ID',
+ *         projectId: 'TENDERLY_PROJECT_ID',
+ *         accessToken: 'TENDERLY_ACCESS_TOKEN',
+ *       },
+ *     },
+ *   },
+ * });
+ */
+export async function handleSetTenderlyCredentials(
+  request: JsonRpcRequest<Record<string, any>>,
+) {
+  if (!request?.params) {
+    throw new Error(
+      'Missing request parameters. Please provide the required parameters for Tenderly access.',
+    );
+  }
+
+  const { accountId, projectId, accessToken } = request.params;
+
+  if (!accountId || !projectId || !accessToken) {
+    throw new Error(
+      'Invalid request parameters. accountId, projectId, and accessToken are required for Tenderly access.',
+    );
+  }
+
+  await snap.request({
+    method: 'snap_manageState',
+    params: {
+      operation: 'update',
+      newState: { accountId, projectId, accessToken },
     },
   });
 

--- a/packages/snap/src/tenderly/utils.ts
+++ b/packages/snap/src/tenderly/utils.ts
@@ -95,5 +95,15 @@ export const isTenderlyDomain = (origin: string) => {
     return false;
   }
 
-  return origin.includes('tenderly.co');
+  try {
+    // Reference: https://developer.mozilla.org/en-US/docs/Web/API/URL
+    const referrer: URL = new URL(origin);
+
+    return (
+      referrer.protocol === 'https:' &&
+      referrer.host.endsWith('dashboard.tenderly.co')
+    );
+  } catch (error) {
+    return false;
+  }
 };

--- a/packages/snap/src/tenderly/utils.ts
+++ b/packages/snap/src/tenderly/utils.ts
@@ -89,3 +89,11 @@ export const formatAmount = (amount: string, decimals = 4) => {
 
   return formatNumber(bnValue.toString(), decimals);
 };
+
+export const isTenderlyDomain = (origin: string) => {
+  if (!origin) {
+    return false;
+  }
+
+  return origin.includes('tenderly.co');
+};


### PR DESCRIPTION
## Description

Added `set_tenderly_credentials` method which updates the snap state with the provided Tenderly credentials.

This method will primarily be used from [Tenderly Dashboard](https://dashboard.tenderly.co) in order to set credentials correctly.

### Example

```ts
await window.ethereum.request({
  method: 'wallet_invokeSnap',
  params: {
    snapId: 'npm:@tenderly/metamask-snap',
    request: {
      method: 'set_tenderly_credentials',
      params: {
        accountId: 'TENDERLY_ACCOUNT_ID',
        projectId: 'TENDERLY_PROJECT_ID',
        accessToken: 'TENDERLY_ACCESS_TOKEN',
      },
    },
  },
});
```

The Snap will update its state by passing the `accountId`, `projectId` and `accessToken` values:

```ts
await snap.request({
  method: 'snap_manageState',
  params: {
    operation: 'update',
    newState: { accountId, projectId, accessToken },
  },
});
```