### PR TITLE
Update credentials fetching and improve error handling

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,13 +1,13 @@
 {
   "version": "1.1.0",
-  "description": "A MetaMask Snap with transaction preview powered by Tenderly Simulation API.",
-  "proposedName": "Tenderly Tx Preview",
+  "description": "Preview transactions before sending them on-chain to get valuable insights, avoid failed transactions, and save funds. Get human-readable information on transferred assets with corresponding dollar values for ERC-20 tokens and NFTs.",
+  "proposedName": "Tenderly TX Preview",
   "repository": {
     "type": "git",
     "url": "https://github.com/tenderly/tenderly-snap.git"
   },
   "source": {
-    "shasum": "rJPQVETMQ5nKH85ThwyqHkneEywg7bIuZqSkGCzpBmc=",
+    "shasum": "TouvEgll0kn1XNEjgUXQi0JzpjEKeS0a5GbpdxnuosA=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/tenderly/tenderly-snap.git"
   },
   "source": {
-    "shasum": "TouvEgll0kn1XNEjgUXQi0JzpjEKeS0a5GbpdxnuosA=",
+    "shasum": "V26OA8LC+H8oSeh/8uaIGJQcKC4q1/v8jjVC3jB0B1k=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/tenderly/credentials-access.ts
+++ b/packages/snap/src/tenderly/credentials-access.ts
@@ -10,12 +10,8 @@ export type TenderlyCredentials = {
 
 /**
  * Fetches the credentials associated with Tenderly project.
- *
- * @param origin - The origin of the request.
  */
-export async function fetchCredentials(
-  origin: string,
-): Promise<TenderlyCredentials | null> {
+export async function fetchCredentials(): Promise<TenderlyCredentials | null> {
   const persistedData: any = await snap.request({
     method: 'snap_manageState',
     params: {
@@ -24,7 +20,6 @@ export async function fetchCredentials(
   });
 
   if (!persistedData) {
-    await handleUpdateTenderlyCredentials(origin);
     return null;
   }
 

--- a/packages/snap/src/tenderly/simulation.ts
+++ b/packages/snap/src/tenderly/simulation.ts
@@ -44,10 +44,14 @@ export async function simulate(
   transaction: { [key: string]: Json },
   transactionOrigin: string,
 ): Promise<Panel> {
-  const credentials = await fetchCredentials(transactionOrigin);
+  const credentials: TenderlyCredentials | null = await fetchCredentials();
 
   if (!credentials) {
-    return panel([text('🚨 Tenderly access token updated. Please try again.')]);
+    return panel([
+      text(
+        '🚨 Your Tenderly credentials seem incorrect or incomplete. Please visit https://dashboard.tenderly.co/account/authorization and connect to Tenderly Snap. If the issue persists, reach out to metamask.snap@tenderly.co for further assistance.',
+      ),
+    ]);
   }
 
   // Get chain id


### PR DESCRIPTION
## Description

Updated Tenderly credentials fetching and improved error handling. Snap dialog should not be shown if Tenderly credentials are not set up. Instead, a descriptive error is shown to the end user.